### PR TITLE
[fix] Echo Nest send back an error on requesting index of greater than 1000

### DIFF
--- a/helpers/playlistHelper.js
+++ b/helpers/playlistHelper.js
@@ -241,7 +241,7 @@ var getArtistTracks = function (artistId) {
 
     echonest.getArtistTotal(artistId)
     .then(function (totalNum) {
-      var total = totalNum;
+      var total = Math.min(totalNum, 1000);
       var index = 0;
       console.log('total: ', total);
       // make requests asynchronously to get all songs


### PR DESCRIPTION
error says:
"Invalid parameter: start + results must be less than 1000"

so fixed to request only 1000 songs