### PR TITLE
[fix] mistake in catching error

### DIFF
--- a/helpers/playlistHelper.js
+++ b/helpers/playlistHelper.js
@@ -61,7 +61,11 @@ function getEchonestData (spotifyUris) {
     // 2) request echonest with songs
     if (spotifyUris.length > 0) {
       console.log(new Date(), 'Request Echonest API ' + spotifyUris.length + ' songs');
-      return echonest.getTrackData(spotifyUris);
+      return echonest.getTrackData(spotifyUris)
+      .catch(echonest.TooManyRequestsError, function (error) {
+        error.tracks = tracks;
+        throw error;
+      });
     }
     return [];
   })
@@ -76,10 +80,6 @@ function getEchonestData (spotifyUris) {
     tracks = tracks.concat(newGhettoNests);
 
     return tracks;
-  })
-  .catch(echonest.TooManyRequestsError, function (error) {
-    error.tracks = tracks;
-    throw error;
   });
 }
 


### PR DESCRIPTION
"GhettoNest.find" does not return a promise. We can call "then" but cannot call "catch".
So I moved "catch" right after "echonest.getTrackData", which returns a Promise.