### PR TITLE
[test] existing-playlist directive tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,10 @@ module.exports = function(config) {
       'public/app/*.js',
       'public/app/player/player.js',
       'public/app/search/search.js',
-      'public/app/**/*.js'
+      'public/app/**/*.js',
+
+      // templates
+      'public/app/existing_playlist/existingPlaylist.html'
     ],
 
 
@@ -39,7 +42,35 @@ module.exports = function(config) {
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    // generate js files from html templates
     preprocessors: {
+      'public/app/existing_playlist/existingPlaylist.html': 'ng-html2js'
+    },
+
+    ngHtml2JsPreprocessor: {
+      // strip this from the file path
+      stripPrefix: 'public/',
+      // stripSuffix: '.ext',
+      // prepend this to the
+      // prependPrefix: 'served/',
+
+      // // or define a custom transform function
+      // // - cacheId returned is used to load template
+      // //   module(cacheId) will return template at filepath
+      // cacheIdFromPath: function(filepath) {
+      //   // example strips 'public/' from anywhere in the path
+      //   // module(app/templates/template.html) => app/public/templates/template.html
+      //   var cacheId = filepath.strip('public/', '');
+      //   return cacheId;
+      // },
+
+      // - setting this option will create only a single module that contains templates
+      //   from all the files, so you can load them all with module('foo')
+      // - you may provide a function(htmlPath, originalPath) instead of a string
+      //   if you'd like to generate modules dynamically
+      //   htmlPath is a originalPath stripped and/or prepended
+      //   with all provided suffixes and prefixes
+      // moduleName: 'foo'
     },
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,7 +70,7 @@ module.exports = function(config) {
       //   if you'd like to generate modules dynamically
       //   htmlPath is a originalPath stripped and/or prepended
       //   with all provided suffixes and prefixes
-      // moduleName: 'foo'
+      moduleName: 'foo'
     },
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,7 +70,7 @@ module.exports = function(config) {
       //   if you'd like to generate modules dynamically
       //   htmlPath is a originalPath stripped and/or prepended
       //   with all provided suffixes and prefixes
-      moduleName: 'foo'
+      moduleName: 'directiveTemplates'
     },
 
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "karma-nested-reporter": "^0.1.1",
+    "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-nyan-reporter": "0.0.43",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon": "^1.0.4",

--- a/public/app/existing_playlist/existingPlaylist.html
+++ b/public/app/existing_playlist/existingPlaylist.html
@@ -1,4 +1,4 @@
 <md-checkbox ng-model="existingPlaylist.playlist.checked" ng-click="existingPlaylist.toggleCheck(existingPlaylist.playlist, !existingPlaylist.playlist.checked)">
   {{ existingPlaylist.playlist.name }}
-  <md-progress-circular class="md-accent" md-diameter="20" md-mode="indeterminate" ng-if="existingPlaylist.playlist.loading"></md-progress-circular>
+  <md-progress-circular class="md-accent playlistSpinner" md-diameter="20" md-mode="indeterminate" ng-if="existingPlaylist.playlist.loading"></md-progress-circular>
 </md-checkbox>

--- a/public/app/existing_playlist/existingPlaylist.js
+++ b/public/app/existing_playlist/existingPlaylist.js
@@ -11,7 +11,7 @@ angular.module('turntify.player')
 
   return {
     restrict: 'EA',
-    templateUrl: '/app/existing_playlist/existingPlaylist.html',
+    templateUrl: 'app/existing_playlist/existingPlaylist.html',
     scope: {
       playlist: '='
     },

--- a/public/app/existing_playlist/existingPlaylist.js
+++ b/public/app/existing_playlist/existingPlaylist.js
@@ -4,7 +4,7 @@ angular.module('turntify.player')
   var controller = function(PlayerService){
     var vm = this;
     vm.toggleCheck = function(playlist, checked){
-      console.log('playlist: ', playlist);
+      // console.log('playlist: ', playlist);
       PlayerService.toggleCheck(playlist, checked);
     };
   };
@@ -20,4 +20,4 @@ angular.module('turntify.player')
     bindToController: true
   };
 
-})
+});

--- a/public/app/existing_playlist/existingPlaylist.js
+++ b/public/app/existing_playlist/existingPlaylist.js
@@ -1,6 +1,6 @@
 
 angular.module('turntify.player')
-.directive('existingPlaylist', function(){
+.directive('existingPlaylist', function(PlayerService){
   var controller = function(PlayerService){
     var vm = this;
     vm.toggleCheck = function(playlist, checked){
@@ -17,7 +17,10 @@ angular.module('turntify.player')
     },
     controller: controller,
     controllerAs: 'existingPlaylist',
-    bindToController: true
+    bindToController: true,
+    link: function(scope, element, attr){
+      console.log('link-test thing', PlayerService.toggleCheck);
+    }
   };
 
 })

--- a/public/app/existing_playlist/existingPlaylist.js
+++ b/public/app/existing_playlist/existingPlaylist.js
@@ -17,10 +17,7 @@ angular.module('turntify.player')
     },
     controller: controller,
     controllerAs: 'existingPlaylist',
-    bindToController: true,
-    link: function(scope, element, attr){
-      console.log('link-test thing', PlayerService.toggleCheck);
-    }
+    bindToController: true
   };
 
 })

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -30,8 +30,8 @@ describe('existingPlaylistDirective', function(){
       $q = _$q_;
       $compile = _$compile_;
 
-      mockPlaylist = {"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"};
-      container = angular.element('<existing-playlist playlist=""></existing-playlist>');
+      mockPlaylist = JSON.stringify({'name':'hip-hop-party','playlistId':'21eoa7xkMxlfjluPVlublp'});
+      container = angular.element('<existing-playlist playlist='+mockPlaylist +'></existing-playlist>');
 
       $compile(container)($scope);
       $scope.$digest();

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -1,34 +1,50 @@
-beforeEach( function() {
-  module('turntify.player', function($provide){
-    /**
-    * Mock the player service
-    */ 
-    $provide.factory('PlayerService', function(){
-      return {
 
-        toggleCheck: sinon.spy(function(){
-          console.log('mock playerservice togglecheck works!!!!');
-          $scope.$broadcast('playlistCollectionUpdated');
-        }),
+describe('existingPlaylistDirective', function(){
+  var $scope, $q, $compile, container, mockPlaylist;
 
-        };
+  beforeEach( function() {
+    module('turntify.player', function($provide){
+      /**
+      * Mock the player service
+      */ 
+      $provide.factory('PlayerService', function(){
+        return {
+
+          toggleCheck: sinon.spy(function(){
+            console.log('mock playerservice togglecheck works!!!!');
+            $scope.$broadcast('playlistCollectionUpdated');
+          }),
+
+          };
+      });
+    });
+
+    // load the templates
+    module('foo');
+
+    inject(function(_$rootScope_, _$compile_, _$q_){
+
+
+      // The injector unwraps the underscores (_) from around the parameter names when matching
+      $scope = _$rootScope_.$new();
+      $q = _$q_;
+      $compile = _$compile_;
+
+      mockPlaylist = {"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"};
+      container = angular.element('<existing-playlist playlist=""></existing-playlist>');
+
+      $compile(container)($scope);
+      $scope.$digest();
     });
   });
 
-  // load the templates
-  module('app/existing_playlist/existingPlaylist.html');
 
-  inject(function(_$rootScope_, _$compile_, _$q_){
+  it('should run the tests', function(){
+    
+      console.log('from existing playlist ',container);
 
-
-    // The injector unwraps the underscores (_) from around the parameter names when matching
-    var $scope = _$rootScope_.$new();
-    var $q = _$q_;
-    var $compile = _$compile_;
-
-    var container = angular.element('<existing-playlist playlist="{"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}"></existing-playlist>');
-
-    $compile(container)($scope);
-    $scope.$digest();
   });
+
+
+
 });

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -15,12 +15,12 @@ describe('existingPlaylistDirective', function(){
             $scope.$broadcast('playlistCollectionUpdated');
           }),
 
-          };
+        };
       });
     });
 
     // load the templates
-    module('foo');
+    module('directiveTemplates');
 
     inject(function(_$rootScope_, _$compile_, _$q_){
 
@@ -39,12 +39,17 @@ describe('existingPlaylistDirective', function(){
   });
 
 
-  it('should run the tests', function(){
-    
-      console.log('from existing playlist ',container);
-
+  it('should contain an md-checkbox element', function(){
+    var checkbox = container.find('md-checkbox');
+    expect(checkbox[0]).to.exist;
+      console.log('from existing playlist ', container);
   });
 
+  it('should print the playlist name', function(){
+    var playlistName = container.find('span').html();
+    console.log('PLAYLIST NAME', playlistName);
+    expect(playlistName).to.have.string('hip-hop-party');
+  });
 
 
 });

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -51,7 +51,7 @@ describe('existingPlaylistDirective', function(){
     expect(playlistName).to.have.string('hip hop party');
   });
 
-  it('should call PlayerService.togglecheck on click', function(){
+  it('should call PlayerService.toggleCheck on click', function(){
     var checkbox = container.find('md-checkbox')[0];
     checkbox.click();
     expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -11,7 +11,6 @@ describe('existingPlaylistDirective', function(){
         return {
 
           toggleCheck: sinon.spy(function(){
-            console.log('mock playerservice togglecheck works!!!!');
             $scope.$broadcast('playlistCollectionUpdated');
           }),
 
@@ -43,7 +42,7 @@ describe('existingPlaylistDirective', function(){
   it('should contain an md-checkbox element', function(){
     var checkbox = container.find('md-checkbox');
     expect(checkbox[0]).to.exist;
-    console.log('from existing playlist ', container);
+    // console.log('from existing playlist ', container);
   });
 
   it('should print the playlist name', function(){

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -15,7 +15,8 @@ beforeEach( function() {
     });
   });
 
-
+  // load the templates
+  module('app/existing_playlist/existingPlaylist.html');
 
   inject(function(_$rootScope_, _$compile_, _$q_){
 
@@ -25,7 +26,7 @@ beforeEach( function() {
     var $q = _$q_;
     var $compile = _$compile_;
 
-    var container = $('<existing-playlist playlist="{"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}"></existing-playlist>');
+    var container = angular.element('<existing-playlist playlist="{"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}"></existing-playlist>');
 
     $compile(container)($scope);
     $scope.$digest();

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -1,6 +1,6 @@
 
 describe('existingPlaylistDirective', function(){
-  var $scope, $q, $compile, container, mockPlaylist;
+  var $scope, $q, $compile, container, mockPlaylist, PlayerServiceMock;
 
   beforeEach( function() {
     module('turntify.player', function($provide){
@@ -22,12 +22,13 @@ describe('existingPlaylistDirective', function(){
     // load the templates
     module('directiveTemplates');
 
-    inject(function(_$rootScope_, _$compile_, _$q_){
+    inject(function(_$rootScope_, _$compile_, _$q_, _PlayerService_){
 
       // The injector unwraps the underscores (_) from around the parameter names when matching
       $scope = _$rootScope_.$new();
       $q = _$q_;
       $compile = _$compile_;
+      PlayerServiceMock = _PlayerService_;
 
       $scope.mockPlaylist = {'name':'hip hop party','playlistId':'21eoa7xkMxlfjluPVlublp'};
 
@@ -42,12 +43,18 @@ describe('existingPlaylistDirective', function(){
   it('should contain an md-checkbox element', function(){
     var checkbox = container.find('md-checkbox');
     expect(checkbox[0]).to.exist;
-      console.log('from existing playlist ', container);
+    console.log('from existing playlist ', container);
   });
 
   it('should print the playlist name', function(){
     var playlistName = container.find('span').html();
     expect(playlistName).to.have.string('hip hop party');
+  });
+
+  it('should call PlayerService.togglecheck on click', function(){
+    var checkbox = container.find('md-checkbox')[0];
+    checkbox.click();
+    expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);
   });
 
 

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -24,14 +24,14 @@ describe('existingPlaylistDirective', function(){
 
     inject(function(_$rootScope_, _$compile_, _$q_){
 
-
       // The injector unwraps the underscores (_) from around the parameter names when matching
       $scope = _$rootScope_.$new();
       $q = _$q_;
       $compile = _$compile_;
 
-      mockPlaylist = JSON.stringify({'name':'hip-hop-party','playlistId':'21eoa7xkMxlfjluPVlublp'});
-      container = angular.element('<existing-playlist playlist='+mockPlaylist +'></existing-playlist>');
+      $scope.mockPlaylist = {'name':'hip hop party','playlistId':'21eoa7xkMxlfjluPVlublp'};
+
+      container = angular.element('<existing-playlist playlist="mockPlaylist"></existing-playlist>');
 
       $compile(container)($scope);
       $scope.$digest();
@@ -47,8 +47,7 @@ describe('existingPlaylistDirective', function(){
 
   it('should print the playlist name', function(){
     var playlistName = container.find('span').html();
-    console.log('PLAYLIST NAME', playlistName);
-    expect(playlistName).to.have.string('hip-hop-party');
+    expect(playlistName).to.have.string('hip hop party');
   });
 
 

--- a/public/app/existing_playlist/existingPlaylist.test.js
+++ b/public/app/existing_playlist/existingPlaylist.test.js
@@ -1,0 +1,33 @@
+beforeEach( function() {
+  module('turntify.player', function($provide){
+    /**
+    * Mock the player service
+    */ 
+    $provide.factory('PlayerService', function(){
+      return {
+
+        toggleCheck: sinon.spy(function(){
+          console.log('mock playerservice togglecheck works!!!!');
+          $scope.$broadcast('playlistCollectionUpdated');
+        }),
+
+        };
+    });
+  });
+
+
+
+  inject(function(_$rootScope_, _$compile_, _$q_){
+
+
+    // The injector unwraps the underscores (_) from around the parameter names when matching
+    var $scope = _$rootScope_.$new();
+    var $q = _$q_;
+    var $compile = _$compile_;
+
+    var container = $('<existing-playlist playlist="{"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}"></existing-playlist>');
+
+    $compile(container)($scope);
+    $scope.$digest();
+  });
+});

--- a/public/app/player/player.test.js
+++ b/public/app/player/player.test.js
@@ -27,6 +27,7 @@ describe('PlayerController', function(){
           });
         }),
 
+        // this func was moved to the existing-playlist directive
         toggleCheck: sinon.spy(function(){
           $scope.$broadcast('playlistCollectionUpdated');
         }),
@@ -71,20 +72,23 @@ describe('PlayerController', function(){
   });
 
 
-  describe('toggleCheck', function(){
-    it('should call PlayerService.toggleCheck', function(){
-      PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
-      expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);
-    });
+  // TOGGLE CHECK WAS MOVED TO THE EXISTING-PLAYLIST DIRECTIVE
+  // TODO: CREATE TESTS FOR THIS FUNCTION ALONG WITH THE REST OF THE DIRECTIVE
 
-    // updates playlistCounter after hearing broadcasted event from PlayerService
-    it('should update playlistCounter', function(){
-      PlayerServiceMock.playlistCounter++;
-      PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
-      expect(PlayerController.playlistCounter).to.equal(1);
-    });
+  // describe('toggleCheck', function(){
+  //   it('should call PlayerService.toggleCheck', function(){
+  //     PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
+  //     expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);
+  //   });
 
-  });
+  //   // updates playlistCounter after hearing broadcasted event from PlayerService
+  //   it('should update playlistCounter', function(){
+  //     PlayerServiceMock.playlistCounter++;
+  //     PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
+  //     expect(PlayerController.playlistCounter).to.equal(1);
+  //   });
+
+  // });
 
 
 });

--- a/public/app/player/player.test.js
+++ b/public/app/player/player.test.js
@@ -75,20 +75,21 @@ describe('PlayerController', function(){
   // TOGGLE CHECK WAS MOVED TO THE EXISTING-PLAYLIST DIRECTIVE
   // TODO: CREATE TESTS FOR THIS FUNCTION ALONG WITH THE REST OF THE DIRECTIVE
 
-  // describe('toggleCheck', function(){
+  describe('udpatePlaylistCounter', function(){
   //   it('should call PlayerService.toggleCheck', function(){
   //     PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
   //     expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);
   //   });
 
-  //   // updates playlistCounter after hearing broadcasted event from PlayerService
-  //   it('should update playlistCounter', function(){
-  //     PlayerServiceMock.playlistCounter++;
-  //     PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
-  //     expect(PlayerController.playlistCounter).to.equal(1);
-  //   });
+    // updates playlistCounter after hearing broadcasted event from PlayerService
+    it('should update playlistCounter on broadcasted event', function(){
+      PlayerServiceMock.playlistCounter++;
+      // PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
+      $scope.$broadcast('playlistCollectionUpdated');
+      expect(PlayerController.playlistCounter).to.equal(1);
+    });
 
-  // });
+  });
 
 
 });

--- a/public/app/player/player.test.js
+++ b/public/app/player/player.test.js
@@ -76,15 +76,9 @@ describe('PlayerController', function(){
   // TODO: CREATE TESTS FOR THIS FUNCTION ALONG WITH THE REST OF THE DIRECTIVE
 
   describe('udpatePlaylistCounter', function(){
-  //   it('should call PlayerService.toggleCheck', function(){
-  //     PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
-  //     expect(PlayerServiceMock.toggleCheck.calledOnce).to.equal(true);
-  //   });
 
-    // updates playlistCounter after hearing broadcasted event from PlayerService
     it('should update playlistCounter on broadcasted event', function(){
       PlayerServiceMock.playlistCounter++;
-      // PlayerController.toggleCheck({"name":"hip hop party","playlistId":"21eoa7xkMxlfjluPVlublp"}, true);
       $scope.$broadcast('playlistCollectionUpdated');
       expect(PlayerController.playlistCounter).to.equal(1);
     });


### PR DESCRIPTION
- Using ng-html2js preprocessor to add html files linked from directive's 'templateURL' property to the templateCache
  - Stops angular from sending a GET to try to load the templates
  - Must strip 'public/' from path so it matches the path called in the directive
