### PR TITLE
[refactor] use ES6 in gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,18 +11,18 @@ import sass from 'gulp-sass';
 
 var server = karma.server;
 
-gulp.task('deleteMin', function(){
+gulp.task('deleteMin', () => {
   del(['./public/assets/css/min/*'], function(err){});
 });
 
-gulp.task('lint', function(){
+gulp.task('lint', () => {
   return  gulp
     .src(['./public/app/**/*.js', './app.js', './controller/*.js', './models/*.js', './middlewares/*.js'])
     .pipe(jshint())
     .pipe(jshint.reporter(stylish));
 });
 
-gulp.task('styles', function(){
+gulp.task('styles', () => {
   return gulp
     .src('./public/assets/css/*.scss')
     .pipe(sass().on('error', sass.logError))
@@ -33,27 +33,27 @@ gulp.task('styles', function(){
 });
 
 // second arg tells gulp that test-client must complete before test-server can run
-gulp.task('test-server', ['test-client'], function(){
+gulp.task('test-server', ['test-client'], () => {
   return gulp.src(['tests/db/*.js', 'tests/server/**/*.js'], { read: false })
     .pipe(mocha({
       reporter: 'spec'
     }))
     // make sure test suite exits once complete
-    .once('error', function (err) {
+    .once('error', (err) => {
       console.log('error & exit');
       process.exit();
     })
-    .once('end', function () {
+    .once('end', () => {
       process.exit();
     });
 });
 
 // takes in a callback (done) so the engine knows when this task is done
-gulp.task('test-client', function(done) {
+gulp.task('test-client', (done) =>  {
   server.start({
     configFile: __dirname + '/karma.conf.js',
     singleRun: true
-  }, function(exitCode) {
+  }, (exitCode) => {
     console.log('Karma has exited with ' + exitCode);
     done(exitCode);
   });

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,15 +1,15 @@
-var gulp = require('gulp'),
-  jshint = require('gulp-jshint'),
-  stylish = require('jshint-stylish'),
-  autoprefix = require('gulp-autoprefixer'),
-  minifyCSS = require('gulp-minify-css'),
-  rename = require('gulp-rename'),
-  del = require('del'),
-  mocha = require('gulp-mocha'),
-  server = require('karma').server,
-  sass = require('gulp-sass');
+import gulp from 'gulp';
+import jshint from 'gulp-jshint';
+import stylish from 'jshint-stylish';
+import autoprefix from 'gulp-autoprefixer';
+import minifyCSS from 'gulp-minify-css';
+import rename from 'gulp-rename';
+import del from 'del';
+import mocha from 'gulp-mocha';
+import karma from 'karma';
+import sass from 'gulp-sass';
 
-
+var server = karma.server;
 
 gulp.task('deleteMin', function(){
   del(['./public/assets/css/min/*'], function(err){});

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,8 +5,8 @@ var gulp = require('gulp'),
   minifyCSS = require('gulp-minify-css'),
   rename = require('gulp-rename'),
   del = require('del'),
-  mocha = require('gulp-mocha')
-  server = require('karma').server
+  mocha = require('gulp-mocha'),
+  server = require('karma').server,
   sass = require('gulp-sass');
 
 
@@ -39,11 +39,12 @@ gulp.task('test-server', ['test-client'], function(){
       reporter: 'spec'
     }))
     // make sure test suite exits once complete
-    .once('error', function () {
-        process.exit(1);
+    .once('error', function (err) {
+      console.log('error & exit');
+      process.exit();
     })
     .once('end', function () {
-        process.exit();
+      process.exit();
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "babel-core": "^5.8.25",
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
     "del": "^1.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <!--link rel="stylesheet" type="text/css" href="./assets/libs/TODO:CHOOSE BASE CSS" /-->
     <link href='https://fonts.googleapis.com/css?family=Fugaz+One' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="./assets/css/app.css" />
+    <link rel="stylesheet" type="text/css" href="./assets/css/min/app.min.css" />
     <!-- <link rel="stylesheet" type="text/css" href="./assets/css/min/app.min.css" /> -->
     <!--link rel="icon" type="image/jpg" href="./assets/favicon.jpg" (or .ico)-->
   </head>

--- a/tests/server/helpers/utilSpec.js
+++ b/tests/server/helpers/utilSpec.js
@@ -69,7 +69,7 @@ describe('sortByTurntness', function () {
 });
 
 describe('solveDuplication', function () {
-  playlistItems = [{
+  var playlistItems = [{
     track: {
       id: '1Oy7KTvDoZKtozZnznYObC',
       name: 'Killer Cars',


### PR DESCRIPTION
- Your gulp CLI must be at 3.9 or greater to run gulp w/ ES6
- gulpfile uses ES6 imports and arrow functions
- Loads the babel-core library
